### PR TITLE
fix: terraform error not being output

### DIFF
--- a/executor_lambda/index.py
+++ b/executor_lambda/index.py
@@ -29,6 +29,9 @@ def exec_call(args, cwd):
     except subprocess.TimeoutExpired as e:
         print(e.output)
         print(e)
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr
+        pass
 
     if stdout:
         pass # print(stdout.decode('utf-8'))


### PR DESCRIPTION
I was running into an issue where the `terraform apply` command would fail silently, and all that was logged in CloudWatch was:

```sh
Command '['/var/task/terraform', 'apply', '-input=false', '-auto-approve', '-no-color']' returned non-zero exit status 1.
```

This properly outputs what the error is.

In my case it was a permissions issue with the service pricipal missing `Application.ReadWrite.All` permission in the Azure portal.

It appears that it was able to create but not update, without that permission.
