### PR TITLE
fix: call cfn init

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -654,6 +654,12 @@ def process_provider(provider_type):
             with open(providerdir / (cfndirname.lower() + ".json"), "w") as f:
                 f.write(json.dumps(schema, indent=4))
             
+            # delete .rpdk-config file
+            if (providerdir / ".rpdk-config").exists():
+                (providerdir / ".rpdk-config").unlink()
+
+            exec_call(['cfn', 'init', '-t', cfntypename, '-a', 'RESOURCE', 'python39', '--use-docker'], providerdir.absolute())
+
             exec_call(['cfn', 'generate'], providerdir.absolute())
 
             # update handlers.py


### PR DESCRIPTION
I'm unsure if this is a recent breaking change or if you have another way of running this, but `generate.py` would not run for me without this change.

Ref: https://github.com/iann0036/cfn-tf-custom-types/issues/7#issuecomment-1966490097